### PR TITLE
Delete publisher on quit

### DIFF
--- a/kng.go
+++ b/kng.go
@@ -443,6 +443,7 @@ func (p *Publisher) runBatchPublisher(ctx context.Context) {
 
 		if quit && remaining == 0 {
 			p.Looper.Quit()
+			p.Kafka.DeletePublisher(ctx, p.Topic)
 			return nil
 		}
 


### PR DESCRIPTION
Publisher was not being removed from map after a quit signal was received, thus the map was never empty and the application will loop infinitely waiting on an empty publisher