### PR TITLE
This adds the ability to set consumer group offsets

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,6 @@ services:
   zookeeper:
     image: antrea/confluentinc-zookeeper:6.2.0
     hostname: zookeeper
-    container_name: zookeeper
     ports:
       - '2181:2181'
     environment:
@@ -13,7 +12,6 @@ services:
   kafka:
     image: antrea/confluentinc-kafka:6.2.0
     hostname: kafka
-    container_name: kafka
     ports:
       - '9092:9092'
       - '9101:9101'
@@ -39,18 +37,13 @@ services:
     depends_on:
       - zookeeper
 
-#  kafka:
-#    image: obsidiandynamics/kafka
-#    restart: "no"
-#    ports:
-#      - "2181:2181"
-#      - "9092:9092"
-#    environment:
-#      KAFKA_LISTENERS: "INTERNAL://:29092,EXTERNAL://:9092"
-#      KAFKA_ADVERTISED_LISTENERS: "INTERNAL://kafka:29092,EXTERNAL://localhost:9092"
-#      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: "INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT"
-#      KAFKA_INTER_BROKER_LISTENER_NAME: "INTERNAL"
-#      KAFKA_ZOOKEEPER_SESSION_TIMEOUT: "6000"
-#      KAFKA_RESTART_ATTEMPTS: "10"
-#      KAFKA_RESTART_DELAY: "5"
-#      ZOOKEEPER_AUTOPURGE_PURGE_INTERVAL: "0"
+  kafdrop:
+    image: obsidiandynamics/kafdrop
+    restart: "no"
+    ports:
+      - "9000:9000"
+    environment:
+      KAFKA_BROKERCONNECT: "kafka:29092"
+      JVM_OPTS: "-Xms16M -Xmx48M -Xss180K -XX:-TieredCompilation -XX:+UseStringDeduplication -noverify"
+    depends_on:
+      - "kafka"

--- a/kng_test.go
+++ b/kng_test.go
@@ -2,6 +2,9 @@ package kng
 
 import (
 	"context"
+	"fmt"
+	"math/rand"
+	"os"
 	"time"
 
 	"github.com/Shopify/sarama"
@@ -10,7 +13,17 @@ import (
 	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 	"github.com/segmentio/kafka-go"
+	"github.com/sirupsen/logrus"
 )
+
+var (
+	log *logrus.Logger
+)
+
+func init() {
+	log = logrus.New()
+	log.SetLevel(logrus.InfoLevel)
+}
 
 var _ = Describe("kng", func() {
 	var (
@@ -39,7 +52,7 @@ var _ = Describe("kng", func() {
 
 			// Verify that topic does not exist (need to use sarama, since
 			// kafka-go doesn't have the functionality
-			clusterAdmin, err := sarama.NewClusterAdmin(k.Options.Brokers, sarama.NewConfig())
+			clusterAdmin, err := sarama.NewClusterAdmin(k.Options.Brokers, newSaramaConfig())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(clusterAdmin).ToNot(BeNil())
 
@@ -49,7 +62,7 @@ var _ = Describe("kng", func() {
 			_, ok := topics[topic]
 			Expect(ok).To(BeFalse())
 
-			// Create topic
+			// Create topic``
 			err = k.CreateTopic(ctx, topic)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -71,7 +84,7 @@ var _ = Describe("kng", func() {
 
 			// Verify that topic does not exist (need to use sarama, since
 			// kafka-go doesn't have the functionality
-			clusterAdmin, err := sarama.NewClusterAdmin(k.Options.Brokers, sarama.NewConfig())
+			clusterAdmin, err := sarama.NewClusterAdmin(k.Options.Brokers, newSaramaConfig())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(clusterAdmin).ToNot(BeNil())
 
@@ -211,6 +224,223 @@ var _ = Describe("kng", func() {
 			Expect(err).To(Equal(ErrMissingPassword))
 		})
 	})
+
+	Context("GetConsumerGroupOffsets", func() {
+		It("should return correct offsets", func() {
+			rand.Seed(time.Now().UnixNano())
+
+			topic := fmt.Sprintf("GetConsumerGroupOffsetsTest-%d", rand.Intn(100_000)+1)
+			cg := topic + "-cg"
+			llog := log.WithField("context", "GetConsumerGroupOffsets")
+
+			llog.Infof("Creating topic '%s'", topic)
+
+			// Create a topic with 4 partitions (4 to ensure that our offset map
+			// partition traversal logic is working properly)
+			err := createTopic(kafkaBrokers, topic, 4)
+			Expect(err).To(BeNil())
+
+			defer func() {
+				if err := cleanupTopic(kafkaBrokers, topic); err != nil {
+					llog.Info("Cleanup topic error: ", err)
+					os.Exit(2)
+				}
+			}()
+
+			// Give kafka a moment to catch up with createTopic
+			time.Sleep(time.Second)
+
+			llog.Info("Publishing messages")
+
+			// Write 100 messages
+			for i := 0; i < 100; i++ {
+				k.Publish(context.Background(), topic, []byte(fmt.Sprintf("test-%d", i)))
+			}
+
+			// Give kng a moment to complete the publishes
+			time.Sleep(5 * time.Second)
+
+			llog.Info("Creating a consumer group")
+
+			// Create consumer group
+			_, err = k.CreateConsumerGroup(context.Background(), topic, cg)
+			Expect(err).To(BeNil())
+
+			// Give consumer group creation a sec to complete
+			time.Sleep(time.Second)
+
+			// Ideally, we would want to clean up the created consumer group(s)
+			// but consumer group deletion in Kafka is a potentially complex and
+			// involved process - need to determine if cg is actively used ->
+			// get member group instance id's -> delete members -> delete cg.
+			// Also, group instance ID's are not supported in sarama which is
+			// what sarama's RemoveMemberFromConsumerGroup() expects. In other
+			// words - not worth it. ~DS 12.20.22
+
+			// Read 100 messages in topic
+			reader := k.NewReader("GetConsumerGroupOffsets-reader", cg, topic)
+			Expect(reader).ToNot(BeNil())
+
+			readerOffsets := make(map[int]int64)
+			var readCount int
+
+			// Kafka _initial_ reads can take a really long time to complete but
+			// we should bail if takes more than a few minutes.
+			ctx, _ := context.WithTimeout(context.Background(), 5*time.Minute)
+
+			llog.Info("Reading messages")
+
+			for {
+				if readCount == 100 {
+					break
+				}
+
+				msg, err := reader.Reader.ReadMessage(ctx)
+				Expect(err).To(BeNil())
+
+				// Record latest offsets for each partition
+				if _, ok := readerOffsets[msg.Partition]; !ok {
+					readerOffsets[msg.Partition] = msg.Offset
+				} else {
+					if msg.Offset > readerOffsets[msg.Partition] {
+						readerOffsets[msg.Partition] = msg.Offset
+					}
+				}
+
+				readCount += 1
+			}
+
+			for k, v := range readerOffsets {
+				llog.Infof("ReaderOffsets: partition: %d offset: %d", k, v)
+			}
+
+			// Close reader (to be polite and allow potential cg removal)
+			err = reader.Reader.Close()
+			Expect(err).To(BeNil(), "should be able to close reader when done")
+
+			llog.Info("Getting consumer group offsets")
+
+			offsets, err := k.GetConsumerGroupOffsets(context.Background(), topic, cg)
+			Expect(err).To(BeNil())
+			Expect(offsets).ToNot(BeNil())
+
+			for k, v := range offsets {
+				llog.Infof("GetConsumerOffsets: partition: %d offset: %d", k, v)
+			}
+
+			// Compare GetConsumerGroupOffsets() result with our readOffset map
+			for readPartition, readOffset := range readerOffsets {
+				_, ok := offsets[readPartition]
+				Expect(ok).To(BeTrue())
+
+				// We need to +1 to get the "NextOffset"
+				Expect(readOffset+1).To(Equal(offsets[readPartition]), "read offsets")
+			}
+		})
+	})
+
+	Context("SetConsumerGroupOffsets", func() {
+		It("should set consumer group offsets", func() {
+			llog := log.WithField("context", "SetConsumerGroupOffsets")
+
+			// Create a topic
+			rand.Seed(time.Now().UnixNano())
+
+			topic := fmt.Sprintf("SetConsumerGroupOffsetsTest-%d", rand.Intn(100_000)+1)
+			cgOld := topic + "-cg-old"
+			cgNew := topic + "-cg-new"
+
+			llog.Infof("Creating topic '%s'", topic)
+
+			err := createTopic(kafkaBrokers, topic)
+			Expect(err).To(BeNil())
+
+			defer func() {
+				if err := cleanupTopic(kafkaBrokers, topic); err != nil {
+					llog.Error("Cleanup topic error: ", err)
+					os.Exit(2)
+				}
+			}()
+
+			// Give kafka a moment to catch up with createTopic
+			time.Sleep(time.Second)
+
+			// Create consumer group 1 ("old" cg)
+			llog.Infof("Creating consumer group '%s'", cgOld)
+
+			_, err = k.CreateConsumerGroup(context.Background(), topic, cgOld)
+			Expect(err).To(BeNil())
+
+			publishCount := 200
+
+			llog.Infof("Publishing '%d' messages to topic '%s'", publishCount, topic)
+
+			// Write 200 messages to topic
+			for i := 0; i < publishCount; i++ {
+				k.Publish(context.Background(), topic, []byte(fmt.Sprintf("old-%d", i)))
+			}
+
+			// Give kng a moment to complete publish
+			time.Sleep(time.Second)
+
+			// Consume 100 messages with cgOld
+			readCount := 100
+
+			readerOld := k.NewReader("SetConsumerGroupOffsets-reader-old", cgOld, topic)
+			Expect(readerOld).ToNot(BeNil())
+
+			llog.Infof("Reading %d messages from topic '%s' using consumer group '%s'", readCount, topic, cgOld)
+
+			for i := 0; i < readCount; i++ {
+				msg, err := readerOld.Reader.FetchMessage(ctx)
+				Expect(err).To(BeNil(), "ReadMessage should not error")
+
+				err = readerOld.Reader.CommitMessages(context.Background(), msg)
+				Expect(err).To(BeNil())
+			}
+
+			// Close reader
+			err = readerOld.Reader.Close()
+			Expect(err).To(BeNil(), "close should not error")
+
+			llog.Infof("Getting latest offsets for consumer group '%s'", cgOld)
+
+			// Get offsets for cgOld
+			ctx, _ = context.WithTimeout(context.Background(), time.Minute)
+
+			offsetsOld, err := k.GetConsumerGroupOffsets(ctx, topic, cgOld)
+			Expect(err).To(BeNil())
+			Expect(offsetsOld).ToNot(BeNil())
+
+			for partition, offset := range offsetsOld {
+				llog.Infof("cgOld: partition '%d' offset '%d'", partition, offset)
+			}
+
+			llog.Infof("Creating & updating consumer group '%s' with offsets from consumer group '%s'", cgNew, cgOld)
+
+			// Update cgNew offsets with cgOld offsets
+			ctx, _ = context.WithTimeout(context.Background(), time.Minute)
+			err = k.SetConsumerGroupOffsets(ctx, topic, cgNew, offsetsOld)
+			Expect(err).To(BeNil())
+
+			// JIC, give kafka a moment to commit new offset
+			time.Sleep(5 * time.Second)
+
+			llog.Infof("Fetching offsets for consumer group '%s'", cgNew)
+
+			// GetNextOffsets should return same offset info as cgOld
+			offsetsNew, err := k.GetConsumerGroupOffsets(context.Background(), topic, cgNew)
+			Expect(err).To(BeNil())
+			Expect(offsetsNew).ToNot(BeNil())
+
+			for partition, offset := range offsetsNew {
+				llog.Infof("cgNew: partition '%d' offset '%d'", partition, offset)
+			}
+
+			// Offsets should be the same
+			Expect(offsetsNew).To(Equal(offsetsOld))
+		})
+	})
 })
 
 func read(brokers []string, topic string) ([]byte, error) {
@@ -242,16 +472,45 @@ func write(brokers []string, topic string, data []byte) error {
 	return nil
 }
 
-func createTopic(brokers []string, topic string) error {
-	clusterAdmin, err := sarama.NewClusterAdmin(brokers, sarama.NewConfig())
+// Sarama defaults to an old kafka API version which does not have support for
+// newer features (like create/delete consumer groups). This helper forces
+// sarama to use a newer API version.
+func newSaramaConfig() *sarama.Config {
+	cfg := sarama.NewConfig()
+	cfg.Version = sarama.V2_6_0_0
+
+	return cfg
+}
+
+func cleanupTopic(brokers []string, topic string) error {
+	clusterAdmin, err := sarama.NewClusterAdmin(brokers, newSaramaConfig())
 	if err != nil {
 		return errors.Wrap(err, "unable to establish cluster admin conn")
 	}
 
-	if err := clusterAdmin.CreateTopic(topic, &sarama.TopicDetail{
+	if err := clusterAdmin.DeleteTopic(topic); err != nil {
+		return errors.Wrapf(err, "unable to delete topic '%s'", topic)
+	}
+
+	return nil
+}
+
+func createTopic(brokers []string, topic string, numPartitions ...int) error {
+	clusterAdmin, err := sarama.NewClusterAdmin(brokers, newSaramaConfig())
+	if err != nil {
+		return errors.Wrap(err, "unable to establish cluster admin conn")
+	}
+
+	topicCfg := &sarama.TopicDetail{
 		NumPartitions:     1,
 		ReplicationFactor: 1,
-	}, false); err != nil {
+	}
+
+	if len(numPartitions) > 0 {
+		topicCfg.NumPartitions = int32(numPartitions[0])
+	}
+
+	if err := clusterAdmin.CreateTopic(topic, topicCfg, false); err != nil {
 		return errors.Wrap(err, "unable to create topic")
 	}
 


### PR DESCRIPTION
I added several other methods to the API that should improve quality of life.

New methods:

* GetTopicPartitions(ctx context.Context, topic string) ([]int, error)
* GetTopicOffsets(ctx context.Context, topic string) ([]kafka.PartitionOffsets, error)
* CreateConsumerGroup(ctx context.Context, topic, cg string) (*kafka.ConsumerGroup, error)
* DeleteConsumerGroup(ctx context.Context, cg string) error
* GetConsumerGroupOffsets(ctx context.Context, topic, cg string) (map[int]int64, error)
* SetConsumerGroupOffsets(ctx context.Context, topic, cg string, offsets map[int]int64) error

Set and Get consumer being the most important ones.

What we were going for was being able to "clone" consumer group settings from an existing consumer group and applying those settings in another consumer group.

To do that you would first do `GetConsumerGroupOffsets()` on the original cg; then run `SetConsumerGroupOffsets()` for the new cg and pass in the offsets that you received from `Get...()`.

This is using a combination of sarama and segment because both have only partial or working functionality for pulling this off.

Sadly, sarama's `ResetOffsets()` via OffsetManager does not work.

:phew: